### PR TITLE
Support for Graphviz Dot export

### DIFF
--- a/src/sgraph/converters/xml_to_dot.py
+++ b/src/sgraph/converters/xml_to_dot.py
@@ -1,0 +1,47 @@
+import sys
+
+from sgraph import SGraph
+
+inputfilepath = sys.argv[1]
+outfilepath = None
+if len(sys.argv) > 2:
+    outfilepath = sys.argv[2]
+
+egm = SGraph.parse_xml_or_zipped_xml(inputfilepath)
+
+def graph_to_dot(g):
+    print('digraph G {')
+    deps = []
+
+    def handle_elem(elem, indent):
+        if elem.children:
+            subgraph_id = id(elem)
+            c = '	'
+            print(c*indent + 'subgraph cluster' + str(subgraph_id) + ' {')
+
+            for child in elem.children:
+                if not child.children:
+                    n = str(id(child))
+                    for assoc in child.outgoing:
+                        used = assoc.toElement
+                        if used.children:
+                            pass
+                        else:
+                            deps.append((n, str(id(used)), assoc.deptype))
+
+                    print(c*(indent+1) + n + ' [label="' + child.name + '"];')
+                else:
+                    handle_elem(child, indent+1)
+            if elem.name:
+                print(c*(indent+1) + 'label = "' + elem.name + '";')
+            print(c*indent+'}')
+    handle_elem(g.rootNode, indent=1)
+    print('')
+    for a, b, t in deps:
+        print('   ' + a + ' -> ' + b + ' [label = "' + t + '"];')
+    print('}')
+
+
+
+graph_to_dot(egm)
+#print(dot)

--- a/src/sgraph/converters/xml_to_dot.py
+++ b/src/sgraph/converters/xml_to_dot.py
@@ -44,4 +44,3 @@ def graph_to_dot(g):
 
 
 graph_to_dot(egm)
-#print(dot)


### PR DESCRIPTION
As described in the screenshot...  ( **graph-easy** is a separate open source tool to visualize graphs in shell using ascii)
 ﻿
![Screenshot from 2021-08-16 22-50-12](https://user-images.githubusercontent.com/5195944/129621823-4a27aebd-97db-490f-90cd-7b4d1a94ef3c.png)

Dot output looks like this: (just the head visible:..)
![Screenshot from 2021-08-16 22-55-53](https://user-images.githubusercontent.com/5195944/129622128-a8196476-aac7-47e8-a9af-9c51af018a56.png)
