### PR TITLE
Avoid failing with non-utf-8 characters when producing XML

### DIFF
--- a/src/sgraph/sgraph.py
+++ b/src/sgraph/sgraph.py
@@ -192,6 +192,7 @@ class SGraph:
                 # https://www.w3.org/TR/xml/#NT-AttValue
                 # Forbidden chars are: naked ampersand, left angle bracket, double quote
                 # single quote is fine as we are using double quotes in XML for attributes
+                v = v.encode('utf-8', 'replace').decode()
                 return v.replace('&', '&amp;').replace('<', '&lt;').replace(
                     '>',
                     '&gt;').replace('\n',


### PR DESCRIPTION
Fix cases when analysis content has been polluted with non-UTF-8 characters.﻿
