### PR TITLE
Fixing unicode encode error case with surrogates

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = sgraph
-version = 0.0.4
+version = 0.0.5
 description = sgraph hierarchic graph data structure, format and algorithms
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
```
File "/usr/local/lib/python3.8/dist-packages/sgraph/sgraph.py", line 256, in dump_node
    dump_node(cc, elem_to_num, reclevel + 1)
  [Previous line repeated 2 more times]
  File "/usr/local/lib/python3.8/dist-packages/sgraph/sgraph.py", line 229, in dump_node
    f.write('<e n="' + enc_xml_a_v(c.name) + '" ' + nattrs + '>\n')
  File "/usr/lib/python3.8/codecs.py", line 721, in write
    return self.writer.write(data)
  File "/usr/lib/python3.8/codecs.py", line 377, in write
    data, consumed = self.encode(object, self.errors)
UnicodeEncodeError: 'utf-8' codec can't encode character '\udce4' in position 11: surrogates not allowed
```
was crashing whole processing. Now the case is handled so that the single attribute value is not saved, but an error is shown in stderr, and the processing continues.