### PR TITLE
modelapi: filter_model fix to contain child elements and descendants

### DIFF
--- a/src/sgraph/modelapi.py
+++ b/src/sgraph/modelapi.py
@@ -155,14 +155,16 @@ class ModelApi:
         # Traverse related elements from the source_graph using stack
         while stack:
             elem = stack.pop(0)
+            new_elem = sub_graph.createOrGetElement(elem)
+            new_elem.attrs = elem.attrs
             for ea in elem.outgoing:
-                selem_from = sub_graph.createOrGetElement(ea.fromElement)
+                selem_from = new_elem
                 selem_to = sub_graph.createOrGetElement(ea.toElement)
                 sea = SElementAssociation(selem_from, selem_to, ea.deptype, ea.attrs)
                 sea.initElems()
             for ea in elem.incoming:
                 selem_from = sub_graph.createOrGetElement(ea.fromElement)
-                selem_to = sub_graph.createOrGetElement(ea.toElement)
+                selem_to = new_elem
                 sea = SElementAssociation(selem_from, selem_to, ea.deptype, ea.attrs)
                 sea.initElems()
             stack.extend(elem.children)


### PR DESCRIPTION
This fixes model filtering to yield descendants also that have no outgoing or incoming associations.
Note: this algorithm is still not optimal from performance point of view. createOrGetElement call should be avoided and create element with help of the earlier created parent element and attach the newly created element on that without searching from the root level every time.  I'll create an issue for this.
