### PR TITLE
Fix missing incoming dependencies in filter_model

### DIFF
--- a/src/sgraph/modelapi.py
+++ b/src/sgraph/modelapi.py
@@ -225,8 +225,8 @@ class ModelApi:
             elif filter_setting == FilterAssocations.DirectAndIndirect:
                 # Get all indirectly and directly used elements into the subgraph, including
                 # their descendant elements.
-                if ea.toElement not in handled:
-                    stack.append(ea.toElement)
+                if related_elem not in handled:
+                    stack.append(related_elem)
 
         handled = set()
         # Traverse related elements from the source_graph using stack

--- a/src/sgraph/modelapi.py
+++ b/src/sgraph/modelapi.py
@@ -161,7 +161,7 @@ class ModelApi:
         """
         Filter a sub graph from source_graph related to source elem.
 
-        When executing model_filter for elem e with "Ignore" mode, it ignores elements
+        When executing filter_model for element e with "Ignore" mode, it ignores elements
         that are external to e.
 
         "Direct" mode changes this behavior: it picks also external elements associated

--- a/tests/sgraph/modelfile_direct_indirect.xml
+++ b/tests/sgraph/modelfile_direct_indirect.xml
@@ -1,0 +1,22 @@
+<model version="2.1">
+  <elements>
+    <e n="foo" >
+      <e i="2" n="bar" >
+          <r r="6" t="inc" />
+      </e>
+    </e>
+    <e n="depends-on-bar" >
+        <e i="3" n="depends-directly-from-bar"  >
+          <r r="2" t="inc" />
+        </e>
+        <e i="4" n="depends-indirectly-from-bar">
+          <r r="3" t="inc" />
+          <r r="6" t="inc" />
+        </e>
+    </e>
+    <e n="other" >
+      <e i="6" n="other-1"></e>
+      <e i="7" n="other-2"></e>
+    </e>
+  </elements>
+</model>


### PR DESCRIPTION
Incoming dependencies were missing if filter_model was called with
```
filter_outgoing=FilterAssocations.Ignore,
filter_incoming=FilterAssocations.DirectAndIndirect
```
Fix by adding also fromElement of element association to stack.