### PR TITLE
use utf-8 for exports

### DIFF
--- a/src/sgraph/sgraph.py
+++ b/src/sgraph/sgraph.py
@@ -279,7 +279,7 @@ class SGraph:
 
     def to_deps(self, fname):
         if fname is not None:
-            f = open(fname, 'w')
+            f = open(fname, 'w', encoding='utf-8')
         else:
             f = sys.stdout
         withDependencies = True
@@ -871,7 +871,7 @@ class SGraph:
 
     def to_plantuml(self, fname):
         if fname is not None:
-            f = open(fname, 'w')
+            f = open(fname, 'w', encoding='utf-8')
         else:
             f = sys.stdout
 


### PR DESCRIPTION
Fixes an issue when the payload contained some characters that couldn't be encoded with the system default (on some hosts system default might be something challenging like cp1252)