### PR TITLE
Major improvements to model filtering and avoiding duplicates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 pandas==1.5.3
 lxml~=4.9.4
-click~=7.1.2
-Levenshtein==0.20.9
+Levenshtein==0.26.0
 pytest==7.1.3
 deprecation==2.1.0
+
+# https://stackoverflow.com/questions/78634235/numpy-dtype-size-changed-may-indicate-binary-incompatibility-expected-96-from
+numpy==1.26.4

--- a/src/sgraph/algorithms/sgraphanalysis.py
+++ b/src/sgraph/algorithms/sgraphanalysis.py
@@ -57,14 +57,14 @@ class SGraphAnalysis:
                             for func_call in f.incoming:
                                 # Self dependencies e.g. recursive calls is not suitable base to
                                 # generate dynamic deps
-                                if func_call.fromElement != func_call.toElement:
-                                    # Do not create new self dependencies
-                                    if func_call.fromElement != f2:
-                                        dynamic_call = SElementAssociation(
-                                            func_call.fromElement, f2,
-                                            'dynamic_' + func_call.deptype, func_call.attrs)
-                                        hash_num = dynamic_call.getHashNum()
-                                        new_deps[hash_num] = dynamic_call
+                                if (func_call.fromElement != func_call.toElement
+                                        and func_call.fromElement != f2
+                                        and not func_call.deptype.startswith('dynamic_')):
+                                    dyn_type = 'dynamic_' + func_call.deptype
+                                    dynamic_call = SElementAssociation(
+                                        func_call.fromElement, f2, dyn_type, func_call.attrs)
+                                    hash_num = dynamic_call.getHashNum()
+                                    new_deps[hash_num] = dynamic_call
 
             else:
                 for c in elemC.children:

--- a/src/sgraph/algorithms/sgraphanalysis.py
+++ b/src/sgraph/algorithms/sgraphanalysis.py
@@ -11,6 +11,16 @@ class SGraphAnalysis:
         :param model:
         :return:
         """
+
+        # Avoid creating duplicate associations with help of hash
+        existing_associations_by_hash = {}
+        stack = [model.rootNode]
+        while stack:
+            elem = stack.pop(0)
+            for assoc in elem.outgoing:
+                existing_associations_by_hash[assoc.getHashNum()] = assoc
+            stack.extend(elem.children)
+
         new_deps = {}
 
         def getOverwrittenMembers(memberF, elemC):
@@ -64,13 +74,15 @@ class SGraphAnalysis:
                                     dynamic_call = SElementAssociation(
                                         func_call.fromElement, f2, dyn_type, func_call.attrs)
                                     hash_num = dynamic_call.getHashNum()
-                                    new_deps[hash_num] = dynamic_call
 
-            else:
-                for c in elemC.children:
-                    findAndCopyAsDynamicDeps(c)
+                                    if hash_num not in existing_associations_by_hash:
+                                        new_deps[hash_num] = dynamic_call
 
-        model.traverse(findAndCopyAsDynamicDeps)
+        stack = [model.rootNode]
+        while stack:
+            elem = stack.pop(0)
+            findAndCopyAsDynamicDeps(elem)
+            stack.extend(elem.children)
 
         for _, dep in sorted(new_deps.items()):
             dep.initElems()

--- a/src/sgraph/algorithms/sgraphfiltering.py
+++ b/src/sgraph/algorithms/sgraphfiltering.py
@@ -11,6 +11,7 @@ class SGraphFiltering:
         """
         Remove dependencies
         :param model:
+        :param dep_types_to_remove:
         :return:
         """
         dep_types_to_remove = set(dep_types_to_remove)
@@ -36,14 +37,16 @@ class SGraphFiltering:
         model.traverse(remove)
 
     @staticmethod
-    def remove_dependencies_by_paths(model: SGraph, from_path, to_path):
+    def remove_dependencies_by_paths(model: SGraph, from_path: str, to_path: str):
         """
         Remove dependencies
-        :param model:
+        :param model: model
+        :param from_path: from elemenet path
+        :param to_path: to element path
         :return:
         """
-        e1 = model.getElementFromPath(from_path)
-        e2 = model.getElementFromPath(to_path)
+        e1 = model.findElementFromPath(from_path)
+        e2 = model.findElementFromPath(to_path)
         remove_assocs_list = []
 
         def remove_eas(elem):
@@ -61,13 +64,14 @@ class SGraphFiltering:
                 r.remove()
 
     @staticmethod
-    def remove_dependencies_by_from_path(model: SGraph, from_path):
+    def remove_dependencies_by_from_path(model: SGraph, from_path: str):
         """
         Remove dependencies
-        :param model:
+        :param model: model
+        :param from_path: from element path
         :return:
         """
-        from_elem = model.getElementFromPath(from_path)
+        from_elem = model.findElementFromPath(from_path)
         if from_elem is None:
             return
 
@@ -88,13 +92,14 @@ class SGraphFiltering:
                 r.remove()
 
     @staticmethod
-    def remove_dependencies_by_to_path(model: SGraph, to_path):
+    def remove_dependencies_by_to_path(model: SGraph, to_path: str):
         """
         Remove dependencies
-        :param model:
+        :param model: model
+        :param to_path: to element path
         :return:
         """
-        to_elem = model.getElementFromPath(to_path)
+        to_elem = model.findElementFromPath(to_path)
         if to_elem is None:
             return
 

--- a/src/sgraph/cli/filter_deps.py
+++ b/src/sgraph/cli/filter_deps.py
@@ -1,25 +1,20 @@
-import click
+import argparse
 import re
 import sys
-"""
+
+doc_message = """
 Use like this:
 
  python3 show_model.py |python3 filter_deps.py --pattern-from /NetflixOSS/External
 
  Or to show main element
 
- python3 show_model.py |grep -v /NetflixOSS/External |python3 filter_deps.py 
-     --pattern-from /\\w+/\\w+ --pattern-to /\\w+/\\w+ --equation a!=b --deps-only True
+ python3 show_model.py |grep -v /NetflixOSS/External |python3 filter_deps.py --pattern-from /\\w+/\\w+ 
+     --pattern-to /\\w+/\\w+ --equation a!=b --deps-only
 
 """
 
 
-@click.command()
-@click.option('--pattern-from', prompt='Pattern FROM', default='', help='Pattern for from element.')
-@click.option('--pattern-to', prompt='Pattern TO', default='', help='Pattern for to element.')
-@click.option('--equation', default='', help='Equation')
-@click.option('--deps-only', default=False, help='Deps only')
-@click.option('--debug', default=False, help='Debug')
 def dofiltering(pattern_from, pattern_to, equation, deps_only, debug):
     """Filter dependencies"""
     pfrom = None
@@ -75,4 +70,12 @@ def dofiltering(pattern_from, pattern_to, equation, deps_only, debug):
 
 
 if __name__ == '__main__':
-    dofiltering()
+    parser = argparse.ArgumentParser(description='Filter dependencies\n' + doc_message)
+    parser.add_argument('--pattern-from', default='', help='Pattern for from element.')
+    parser.add_argument('--pattern-to', default='', help='Pattern for to element.')
+    parser.add_argument('--equation', default='', help='Equation')
+    parser.add_argument('--deps-only', action='store_true', help='Deps only')
+    parser.add_argument('--debug', action='store_true', help='Debug')
+
+    args = parser.parse_args()
+    dofiltering(args.pattern_from, args.pattern_to, args.equation, args.deps_only, args.debug)

--- a/src/sgraph/converters/sbom_cyclonedx_generator.py
+++ b/src/sgraph/converters/sbom_cyclonedx_generator.py
@@ -84,7 +84,7 @@ def bom_ref(elem, v):
 license_mapping_to_spdx_id = {}
 
 
-def resolve_license_spdx_id(license, elem):
+def resolve_license_spdx_id(license):
     acceptable_licenses = {'MIT'}
     if license in acceptable_licenses:
         return license
@@ -106,7 +106,7 @@ def bom_licenses(elem):
         'SPDX_OTHER_TODO': ''
     }
     if 'license' in elem.attrs:
-        license_spdx_id = resolve_license_spdx_id(elem.attrs['license'], elem)
+        license_spdx_id = resolve_license_spdx_id(elem.attrs['license'])
         return [{
             'license': {
                 'id': license_spdx_id,
@@ -164,7 +164,8 @@ def elem_as_bom_data(elem, other_externals_by_name):
         }
       ]
 
-    :param elem:
+    :param elem: element
+    :param other_externals_by_name: dict of external elements by name
     :return:
     """
     licenses = bom_licenses(elem)

--- a/src/sgraph/definitions.py
+++ b/src/sgraph/definitions.py
@@ -1,0 +1,14 @@
+from enum import Enum
+
+
+class FilterAssocations(Enum):
+    Ignore = 1
+    Direct = 2
+    DirectAndIndirect = 3
+
+
+class HaveAttributes(Enum):
+    Ignore = 1
+    IncludeCopy = 2
+    IncludeReference = 3
+

--- a/src/sgraph/graphdataservice.py
+++ b/src/sgraph/graphdataservice.py
@@ -51,11 +51,6 @@ def get_latest_model(output_dir, analysis_target_name):
                 modelpath = ts_dir + '/model.xml.zip'
                 if os.path.exists(modelpath):
                     modelpaths.append(modelpath)
-                else:
-                    # Use old modelpath
-                    modelpath = ts_dir + '/dependency/modelfile.xml.zip'
-                    if os.path.exists(modelpath):
-                        modelpaths.append(modelpath)
     if modelpaths:
         modelpaths.sort()
         modelpath = modelpaths[-1]

--- a/src/sgraph/graphdataservice.py
+++ b/src/sgraph/graphdataservice.py
@@ -8,7 +8,31 @@ from sgraph import ModelApi
 from sgraph import SGraph
 
 
-def extract_subgraph_as_json(analysis_target_name, output_dir, element_path, recursion, flavour):
+def extract_subgraph_as_json(analysis_target_name, output_dir, element_path, _recursion, flavour):
+    """
+    Extracts subraph as JSOn. recursion parameter not yet supported.
+    :param analysis_target_name:
+    :param output_dir:
+    :param element_path:
+    :param _recursion:
+    :param flavour:
+    :return:
+    """
+    subgraph = extract_filtered_subgraph(analysis_target_name, output_dir, element_path)
+    return produce_output(flavour, subgraph)
+
+
+def extract_filtered_subgraph(analysis_target_name, output_dir, element_path):
+        graph = extract_and_load(analysis_target_name, output_dir)
+        elem = graph.createOrGetElementFromPath(element_path)
+        if elem:
+            # TODO handle also recursion param
+            return ModelApi().filter_model(elem, graph)
+        else:
+            raise Exception(f'Element path {element_path} not found')
+
+
+def extract_and_load(analysis_target_name, output_dir):
     modelfile = get_latest_model(output_dir, analysis_target_name)
     if modelfile is None:
         raise ModelNotFoundException(
@@ -22,13 +46,7 @@ def extract_subgraph_as_json(analysis_target_name, output_dir, element_path, rec
         data = io.TextIOWrapper(data)
         zfile.close()
         graph = SGraph.parse_xml(data)
-        elem = graph.createOrGetElementFromPath(element_path)
-        if elem:
-            # TODO handle also recursion param
-            subgraph = ModelApi().filter_model(elem, graph)
-            return produce_output(flavour, subgraph)
-        else:
-            raise Exception(f'Element path {element_path} not found')
+        return graph
 
 
 def produce_output(outputformat, subg):

--- a/src/sgraph/loader/attributeloader.py
+++ b/src/sgraph/loader/attributeloader.py
@@ -11,13 +11,15 @@ class AttributeLoader:
         pass
 
     # noinspection PyMethodMayBeStatic
-    def load_attrfile(self, filepath, model: SGraph):
+    def load_attrfile(self, filepath, model: SGraph, ignored_attributes: list[str]):
         columns, entries = attributequeries.read_attrs_generic(filepath)
         for elem_path, attrs in entries:
             if isinstance(elem_path, int):
                 raise Exception(f'Invalid attribute file {filepath} as id {elem_path} is numeric..')
             elem = model.createOrGetElementFromPath(elem_path)
             for c in columns:
+                if c in ignored_attributes:
+                    continue
                 val = attrs[c]
                 if not isinstance(val, str):
                     val = '' if math.isnan(val) else val
@@ -26,7 +28,7 @@ class AttributeLoader:
 
         return model
 
-    def load_all_files(self, model, filepath_of_model_root):
+    def load_all_files(self, model, filepath_of_model_root, ignored_attributes):
 
         attrfiles = ['attr_temporary.csv', 'git/attr_git_propagated.csv',
                      'git/attr_analysis_state.csv', 'content/loc/attr_loc_propagated.csv',
@@ -39,13 +41,13 @@ class AttributeLoader:
             fullpath = filepath_of_model_root + '/' + attrfile + '.zip'
             if os.path.exists(fullpath) and os.path.isfile(fullpath):
                 # Usual case, when this is done after zipper postprocessor
-                self.load_attrfile(fullpath, model)
+                self.load_attrfile(fullpath, model, ignored_attributes)
             else:
                 # Without .zip extension
                 # Attributes can be loaded in data mining phase, when zipper has not been executed.
                 fullpath = filepath_of_model_root + '/' + attrfile
                 if os.path.exists(fullpath) and os.path.isfile(fullpath):
-                    self.load_attrfile(fullpath, model)
+                    self.load_attrfile(fullpath, model, ignored_attributes)
                 else:
                     attribute_files_missing.append(attrfile)
         return model, attribute_files_missing

--- a/src/sgraph/loader/modelloader.py
+++ b/src/sgraph/loader/modelloader.py
@@ -46,7 +46,7 @@ class ModelLoader:
             filepath_of_model_root = filepath.replace('/dependency/modelfile.xml.zip', '').replace(
                 '/dependency/modelfile.xml', '')
             a = AttributeLoader()
-            model, missing_attr_files = a.load_all_files(model, filepath_of_model_root)
+            model, missing_attr_files = a.load_all_files(model, filepath_of_model_root, ignored_attributes)
 
             for missing in missing_attr_files:
                 if missing != 'attr_temporary.csv':
@@ -62,8 +62,7 @@ class ModelLoader:
         return model
 
     # noinspection PyMethodMayBeStatic
-    def load_attributes(self, model: SGraph, filepath: str, dep_types: list = None,
-                        ignored_attributes: list = None) -> SGraph:
+    def load_attributes(self, model: SGraph, filepath: str, ignored_attributes: list = None) -> SGraph:
         """
         Loads attribute files of a model.
         When returning model and [None], it means that the model path did not match to the usual
@@ -74,21 +73,16 @@ class ModelLoader:
 
         :param model:
         :param filepath: model filepath
-        :param dep_types: dependency types list or None
         :param ignored_attributes: list of attribute names to ignore while parsing XML model or None
         :return: the model SGraph object
         """
         ignored_attributes = ignored_attributes or []
 
-        if dep_types is None:
-            # TODO Not used.
-            dep_types = ['IGNORE dynamic_function_ref', 'IGNORE dynamic_typeref_member']
-
         # TODO What else would good to hide by default, maybe everything dynamic_*?
         filepath_of_model_root = filepath.replace('/dependency/modelfile.xml.zip', '').replace(
             '/dependency/modelfile.xml', '')
         a = AttributeLoader()
-        model, missing_attr_files = a.load_all_files(model, filepath_of_model_root)
+        model, missing_attr_files = a.load_all_files(model, filepath_of_model_root, ignored_attributes)
 
         for missing in missing_attr_files:
             if missing != 'attr_temporary.csv':

--- a/src/sgraph/modelapi.py
+++ b/src/sgraph/modelapi.py
@@ -22,7 +22,7 @@ class ModelApi:
         self.egm = model
 
     def getElementByPath(self, filepath):
-        return self.egm.getElementFromPath(filepath)
+        return self.egm.findElementFromPath(filepath)
 
     def getChildrenByType(self, element, elemType):
         return [x for x in element.children if x.typeEquals(elemType)]

--- a/src/sgraph/modelapi.py
+++ b/src/sgraph/modelapi.py
@@ -1,15 +1,10 @@
+import copy
 import functools
-from enum import Enum
 
 from sgraph import SElement
 from sgraph import SElementAssociation
 from sgraph import SGraph
-
-
-class FilterAssocations(Enum):
-    Ignore = 1
-    Direct = 2
-    DirectAndIndirect = 3
+from sgraph.definitions import FilterAssocations, HaveAttributes
 
 
 class ModelApi:
@@ -156,7 +151,8 @@ class ModelApi:
 
     def filter_model(self, source_elem, source_graph,
                      filter_outgoing: FilterAssocations = FilterAssocations.Direct,
-                     filter_incoming: FilterAssocations = FilterAssocations.Direct):
+                     filter_incoming: FilterAssocations = FilterAssocations.Direct,
+                     have_attributes: HaveAttributes = HaveAttributes.IncludeCopy):
         """
         Filter a sub graph from source_graph related to source elem.
 
@@ -176,11 +172,12 @@ class ModelApi:
         :param source_graph: the overall graph to be filtered
         :param filter_outgoing: filtering mode for outgoing dependencies
         :param filter_incoming: filtering mode for incoming dependencies
+        :param have_attributes: have attributes included, either as copy or reference, or ignore
         :return: new graph, that contains independent new SElement objects with same topology as
         in the source_graph
         """
         sub_graph = SGraph()
-        sub_graph.createOrGetElement(source_elem)
+        _elem, _is_new = sub_graph.create_or_get_element(source_elem)
         stack = [source_elem]
 
         def is_descendant_of_source_elem(element):
@@ -191,7 +188,7 @@ class ModelApi:
                     return True
 
         def create_assoc(x, other, is_outgoing, ea):
-            new_or_existing_referred_elem, is_new = sub_graph.create_or_get_element(x)
+            new_or_existing_referred_elem, this_is_new = sub_graph.create_or_get_element(x)
 
             if is_outgoing:
                 SElementAssociation(other, new_or_existing_referred_elem, ea.deptype,
@@ -201,31 +198,30 @@ class ModelApi:
                 SElementAssociation(new_or_existing_referred_elem, other, ea.deptype,
                                     ea.attrs).initElems()
 
-            return new_or_existing_referred_elem, is_new
+            return new_or_existing_referred_elem, this_is_new
 
-        def handle_assocation(ea, related_elem, filter_setting, is_outgoing, stack):
+        def handle_assocation(the_elem, ea, related_elem, filter_setting, is_outgoing, assoc_stack):
             descendant_of_src = is_descendant_of_source_elem(related_elem)
 
             if not descendant_of_src and filter_setting == FilterAssocations.Ignore:
                 return
 
-            new_or_existing_referred_elem, is_new = create_assoc(related_elem, new_elem,
-                                                                 is_outgoing, ea)
+            new_or_existing_referred_elem, this_new = create_assoc(related_elem, the_elem, is_outgoing, ea)
 
             if descendant_of_src:
                 # No need to create descendants since those will be anyway created later as part of
                 # the main iteration.
                 return
             elif filter_setting == FilterAssocations.Direct:
-                if is_new:
+                if this_new:
                     # Avoid creating descendants multiple times.
-                    self.create_descendants(related_elem, new_or_existing_referred_elem)
+                    self.create_descendants(related_elem, new_or_existing_referred_elem, have_attributes)
 
             elif filter_setting == FilterAssocations.DirectAndIndirect:
                 # Get all indirectly and directly used elements into the subgraph, including
                 # their descendant elements.
                 if related_elem not in handled:
-                    stack.append(related_elem)
+                    assoc_stack.append(related_elem)
 
         handled = set()
         # Traverse related elements from the source_graph using stack
@@ -233,40 +229,55 @@ class ModelApi:
             elem = stack.pop(0)
             handled.add(elem)
 
-            new_elem = sub_graph.createOrGetElement(elem)
-            new_elem.attrs = elem.attrs
-
+            the_elem, _is_new = sub_graph.create_or_get_element(elem)
             for association in elem.outgoing:
-                handle_assocation(association, association.toElement, filter_outgoing,
+                handle_assocation(the_elem, association, association.toElement, filter_outgoing,
                                   True, stack)
 
             for association in elem.incoming:
-                handle_assocation(association, association.fromElement, filter_incoming,
+                handle_assocation(the_elem, association, association.fromElement, filter_incoming,
                                   False, stack)
 
             stack.extend(elem.children)
 
         # Now that elements have been created, copy attribute data from the whole graph, via
-        # traversal using two stacks.
-        stack = [sub_graph.rootNode]
-        whole_graph_stack = [source_graph.rootNode]
-        while stack:
-            elem = stack.pop(0)
-            corresponding_source_elem = whole_graph_stack.pop(0)
-            elem.attrs = corresponding_source_elem.attrs.copy()
-            for elem in elem.children:
-                stack.append(elem)
-                whole_graph_stack.append(corresponding_source_elem.getChildByName(elem.name))
+        # traversal using two stacks. Earlier phases did not grab attributes on purpose, to make things
+        # more simple.
+        if have_attributes in (HaveAttributes.IncludeReference, HaveAttributes.IncludeCopy):
+            stack = [sub_graph.rootNode]
+            whole_graph_stack = [source_graph.rootNode]
+            while stack:
+                elem = stack.pop(0)
+                corresponding_source_elem = whole_graph_stack.pop(0)
+
+                if have_attributes == HaveAttributes.IncludeReference:
+                    elem.attrs = corresponding_source_elem.attrs
+                elif have_attributes == HaveAttributes.IncludeCopy:
+                    elem.attrs = corresponding_source_elem.attrs.copy()
+
+                for elem in elem.children:
+                    stack.append(elem)
+                    whole_graph_stack.append(corresponding_source_elem.getChildByName(elem.name))
+        elif have_attributes == HaveAttributes.Ignore:
+            pass
 
         return sub_graph
 
-    def create_descendants(self, related_elem: SElement, new_or_existing_referred_elem: SElement):
-
+    def create_descendants(self, related_elem: SElement, new_or_existing_referred_elem: SElement,
+                           have_attributes: HaveAttributes = HaveAttributes.Ignore):
         stack = [(related_elem, new_or_existing_referred_elem)]
         while stack:
-            orig, new = stack.pop(0)
+            orig_and_new: tuple[SElement, SElement] = stack.pop(0)
 
-            if orig.children:
-                for child in orig.children:
-                    new_child = new.createOrGetElement(child.name)
+            if orig_and_new[0].children:
+                for child in orig_and_new[0].children:
+                    new_child, is_new = orig_and_new[1].create_or_get_element(child.name)
+                    if is_new:
+                        if have_attributes == HaveAttributes.IncludeReference:
+                            new_child.attrs = child.attrs
+                        elif have_attributes == HaveAttributes.IncludeCopy:
+                            new_child.attrs = copy.copy(child.attrs)
+                        elif have_attributes == HaveAttributes.Ignore:
+                            pass
+                        stack.append((child, new_child))
                     stack.append((child, new_child))

--- a/src/sgraph/selement.py
+++ b/src/sgraph/selement.py
@@ -9,7 +9,7 @@ DEBUG = False
 
 class SElement:
     __slots__ = 'name', 'parent', 'children', 'childrenDict', 'outgoing', 'incoming', 'attrs', \
-                'human_readable_name'
+        'human_readable_name'
 
     def __init__(self, parent: Optional['SElement'], name: str):
         if name == '':
@@ -33,8 +33,8 @@ class SElement:
                 if DEBUG:
                     raise Exception('Error: overlapping elements related to {} under {}, types: '
                                     '{} and {}'.format(
-                                        self.name, self.parent.getPath(), '<not known>',
-                                        self.parent.childrenDict[self.name].getType()))
+                        self.name, self.parent.getPath(), '<not known>',
+                        self.parent.childrenDict[self.name].getType()))
                 else:
                     raise SElementMergedException(
                         'Element {} tried to be merged with an existing element '
@@ -491,7 +491,7 @@ class SElement:
 
         for association in list(other.outgoing):
             if association.toElement in current_deps and association.deptype in current_deps[
-                    association.toElement]:
+                association.toElement]:
                 # already exists
                 pass
             elif self != association.toElement:
@@ -508,7 +508,7 @@ class SElement:
 
         for association in list(other.incoming):
             if association.fromElement in current_deps and association.deptype in current_deps[
-                    association.fromElement]:
+                association.fromElement]:
                 # already exists
                 pass
             elif association.fromElement != self:

--- a/src/sgraph/sgraph.py
+++ b/src/sgraph/sgraph.py
@@ -19,6 +19,7 @@ import zipfile
 from typing import Optional
 from xml.sax import parseString
 
+from .definitions import HaveAttributes
 from .selement import SElement
 from .selementassociation import SElementAssociation
 
@@ -468,7 +469,7 @@ class SGraph:
             return parentMatch.getChildByName(elem.name)
 
     def createOrGetElement(self, elem: SElement):
-        elems = list(reversed(elem.getPathAsList()))
+        elems = elem.get_ancestor_names_list()
 
         p = self.rootNode
         for i in range(len(elems)):
@@ -487,7 +488,7 @@ class SGraph:
         :param elem:
         :return: tuple of the matched element and boolean describing if new element was created.
         """
-        elems = list(reversed(elem.getPathAsList()))
+        elems = elem.get_ancestor_names_list()
 
         p = self.rootNode
         for i in range(len(elems)):


### PR DESCRIPTION
- **avoid duplicating dynamic_* deps**
- **requirements: update Levenshtein to 0.26.0, remove click dependency**
- **support dep type filters and ignored attributes list, when loading the model**
- **code cleanup, remove legacy code**
- **avoid creating duplicate associations**
- **refactor model subgraph filtering to modular functions**
- **make model filtering more parametrizable: include attrs or not**
