### PR TITLE
Fix packaging: declare Levenshtein dep, repair hierarchical JSON converter, remove stale release tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,9 +29,10 @@ project_urls =
 [options]
 packages = find:
 python_requires = >=3.8
-install_requires = 
+install_requires =
 	pandas>=1.5.3
 	lxml>=5.3.0
+	Levenshtein>=0.25.1
 package_dir = 
 	= src
 

--- a/src/sgraph/converters/xml_to_hierarchical_json.py
+++ b/src/sgraph/converters/xml_to_hierarchical_json.py
@@ -2,6 +2,12 @@
 import sys
 
 from sgraph import SGraph
-from sgraph_json import sgraph_to_json_file
+from sgraph.converters.sgraph_json import sgraph_to_json_file
 
-sgraph_to_json_file(SGraph.parse_xml_or_zipped_xml(sys.argv[1]), sys.argv[2])
+
+def main():
+    sgraph_to_json_file(SGraph.parse_xml_or_zipped_xml(sys.argv[1]), sys.argv[2])
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/converters/test_xml_to_hierarchical_json.py
+++ b/tests/converters/test_xml_to_hierarchical_json.py
@@ -1,0 +1,23 @@
+import json
+import os
+import sys
+
+
+def test_module_is_importable():
+    """Regression test: the module used to import a nonexistent top-level
+    sgraph_json module and run the conversion at import time."""
+    import sgraph.converters.xml_to_hierarchical_json  # noqa: F401
+
+
+def test_main_converts_model_to_json(tmp_path, monkeypatch):
+    from sgraph.converters import xml_to_hierarchical_json
+
+    model_path = os.path.join(os.path.dirname(__file__), 'model.xml')
+    output_path = str(tmp_path / 'output.json')
+    monkeypatch.setattr(sys, 'argv', ['xml_to_hierarchical_json', model_path, output_path])
+
+    xml_to_hierarchical_json.main()
+
+    with open(output_path) as f:
+        doc = json.load(f)
+    assert doc

--- a/tests/test_release_automation.py
+++ b/tests/test_release_automation.py
@@ -1,11 +1,10 @@
 """Tests for release automation script.
 
-These tests verify the PR polling mechanism works correctly in various scenarios.
+These tests verify version bumping, PR creation, and PR number extraction.
 """
 
-import json
 import pytest
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import patch
 import subprocess
 import sys
 import os
@@ -13,137 +12,50 @@ import os
 # Add scripts directory to path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'scripts'))
 
-from release import ReleaseAutomation, ReleaseError
+from release import ReleaseAutomation, ReleaseError  # noqa: E402
 
 
-class TestPollForPrMerge:
-    """Tests for the _poll_for_pr_merge method."""
+class TestBumpVersion:
+    """Tests for the bump_version method."""
 
     def setup_method(self):
         """Set up test fixtures."""
-        self.automation = ReleaseAutomation(dry_run=False, skip_confirmation=True)
-        self.automation.repo_root = "/fake/repo"
+        self.automation = ReleaseAutomation(dry_run=True)
 
-    @patch('release.subprocess.run')
-    @patch('release.time.sleep')
-    def test_detects_merged_pr_by_state(self, mock_sleep, mock_run):
-        """Test that polling detects a merged PR correctly."""
-        # Simulate gh pr view returning MERGED state
-        mock_run.return_value = subprocess.CompletedProcess(
-            args=[],
-            returncode=0,
-            stdout='{"state": "MERGED"}',
-            stderr=""
-        )
+    def test_bump_patch(self):
+        assert self.automation.bump_version("1.5.1", "patch") == "1.5.2"
 
-        # Should return without error when PR is merged
-        self.automation._poll_for_pr_merge("releasing-1.0.0", timeout_minutes=1)
+    def test_bump_minor(self):
+        assert self.automation.bump_version("1.5.1", "minor") == "1.6.0"
 
-        # Verify gh was called with branch name
-        mock_run.assert_called()
-        call_args = mock_run.call_args[0][0]
-        assert "gh" in call_args
-        assert "pr" in call_args
-        assert "view" in call_args
+    def test_bump_major(self):
+        assert self.automation.bump_version("1.5.1", "major") == "2.0.0"
 
-    @patch('release.subprocess.run')
-    @patch('release.time.sleep')
-    def test_detects_closed_pr_raises_error(self, mock_sleep, mock_run):
-        """Test that polling raises error when PR is closed without merge."""
-        mock_run.return_value = subprocess.CompletedProcess(
-            args=[],
-            returncode=0,
-            stdout='{"state": "CLOSED"}',
-            stderr=""
-        )
+    def test_invalid_version_raises_error(self):
+        with pytest.raises(ReleaseError):
+            self.automation.bump_version("not-a-version", "patch")
 
-        with pytest.raises(ReleaseError) as exc_info:
-            self.automation._poll_for_pr_merge("releasing-1.0.0", timeout_minutes=1)
+    def test_invalid_bump_type_raises_error(self):
+        with pytest.raises(ReleaseError):
+            self.automation.bump_version("1.5.1", "gigantic")
 
-        assert "closed without merging" in str(exc_info.value).lower()
 
-    @patch('release.subprocess.run')
-    @patch('release.time.sleep')
-    def test_handles_branch_deleted_after_merge(self, mock_sleep, mock_run):
-        """Test that polling handles the case where branch is deleted after PR merge.
+class TestExtractPrNumber:
+    """Tests for the _extract_pr_number method."""
 
-        This is the bug we're fixing: when a PR is merged, GitHub deletes the branch,
-        and 'gh pr view <branch-name>' returns 'no pull requests found'.
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.automation = ReleaseAutomation(dry_run=True)
 
-        The fix: capture PR number when creating PR, then poll by number.
-        'gh pr view <number>' works even after branch is deleted.
-        """
-        # Simulate: first call with branch name fails (branch deleted),
-        # then call with PR number succeeds showing MERGED
-        mock_run.side_effect = [
-            # First: gh pr view <branch-name> fails - branch deleted after merge
-            subprocess.CompletedProcess(
-                args=[], returncode=1, stdout="",
-                stderr="no pull requests found for branch \"releasing-1.0.0\""
-            ),
-            # Second: gh pr view <number> succeeds - shows merged
-            subprocess.CompletedProcess(
-                args=[], returncode=0,
-                stdout='{"state": "MERGED"}', stderr=""
-            ),
-        ]
+    def test_extracts_number_from_pr_url(self):
+        output = "https://github.com/softagram/sgraph/pull/456"
+        assert self.automation._extract_pr_number(output) == 456
 
-        # After fix: should detect merge by falling back to PR number
-        # and return successfully (no exception)
-        self.automation._poll_for_pr_merge(
-            "releasing-1.0.0",
-            timeout_minutes=1,
-            poll_interval_seconds=0.001,
-            pr_number=123  # New parameter: PR number for fallback
-        )
+    def test_returns_none_for_empty_output(self):
+        assert self.automation._extract_pr_number("") is None
 
-        # Should have made 2 calls - first by branch, then by number
-        assert mock_run.call_count == 2
-
-    @patch('release.subprocess.run')
-    @patch('release.time.sleep')
-    def test_waits_for_open_pr(self, mock_sleep, mock_run):
-        """Test that polling continues waiting while PR is open."""
-        # First call: PR is open, second call: PR is merged
-        mock_run.side_effect = [
-            subprocess.CompletedProcess(
-                args=[], returncode=0,
-                stdout='{"state": "OPEN"}', stderr=""
-            ),
-            subprocess.CompletedProcess(
-                args=[], returncode=0,
-                stdout='{"state": "MERGED"}', stderr=""
-            ),
-        ]
-
-        self.automation._poll_for_pr_merge(
-            "releasing-1.0.0",
-            timeout_minutes=1,
-            poll_interval_seconds=0.001
-        )
-
-        # Should have polled twice
-        assert mock_run.call_count == 2
-
-    @patch('release.subprocess.run')
-    @patch('release.time.sleep')
-    def test_timeout_when_pr_never_merges(self, mock_sleep, mock_run):
-        """Test that polling times out if PR stays open."""
-        mock_run.return_value = subprocess.CompletedProcess(
-            args=[],
-            returncode=0,
-            stdout='{"state": "OPEN"}',
-            stderr=""
-        )
-
-        with pytest.raises(ReleaseError) as exc_info:
-            self.automation._poll_for_pr_merge(
-                "releasing-1.0.0",
-                timeout_minutes=0.01,
-                poll_interval_seconds=0.001
-            )
-
-        assert "timeout" in str(exc_info.value).lower()
+    def test_returns_none_when_no_pr_url_present(self):
+        assert self.automation._extract_pr_number("no url here") is None
 
 
 class TestPushAndCreatePr:
@@ -160,7 +72,6 @@ class TestPushAndCreatePr:
         """Test that PR number is extracted and returned when creating PR.
 
         The gh pr create command outputs the PR URL, which contains the PR number.
-        We need to capture this to use for polling later.
         """
         # gh CLI is available
         mock_subprocess.return_value = subprocess.CompletedProcess(
@@ -180,7 +91,6 @@ class TestPushAndCreatePr:
             ),
         ]
 
-        # After fix, this should return the PR number
         result = self.automation.push_and_create_pr("releasing-1.0.0", "1.0.0")
 
         # Should return PR number extracted from URL
@@ -204,36 +114,3 @@ class TestPushAndCreatePr:
 
         # Should return None when gh is not available
         assert result is None
-
-
-class TestPollWithPrNumber:
-    """Tests for polling using PR number instead of branch name."""
-
-    def setup_method(self):
-        """Set up test fixtures."""
-        self.automation = ReleaseAutomation(dry_run=False, skip_confirmation=True)
-        self.automation.repo_root = "/fake/repo"
-
-    @patch('release.subprocess.run')
-    @patch('release.time.sleep')
-    def test_poll_by_pr_number_works_after_branch_deleted(self, mock_sleep, mock_run):
-        """Test that polling by PR number works even after branch is deleted.
-
-        This is the key test for the fix: using PR number instead of branch name
-        allows us to check status even after the branch is deleted post-merge.
-        """
-        # When polling by PR number, gh pr view <number> returns MERGED
-        mock_run.return_value = subprocess.CompletedProcess(
-            args=[],
-            returncode=0,
-            stdout='{"state": "MERGED"}',
-            stderr=""
-        )
-
-        # After fix, we should be able to poll by PR number
-        # This method doesn't exist yet - we'll add it
-        # self.automation._poll_for_pr_merge_by_number(123, timeout_minutes=1)
-
-        # For now, verify the standard poll works with mocked MERGED state
-        self.automation._poll_for_pr_merge("releasing-1.0.0", timeout_minutes=1)
-        assert mock_run.called


### PR DESCRIPTION
## Summary

Three fixes discovered during the 1.6.0 release verification:

1. **Missing dependency**: `sgraph.compare.similarityanalysis` imports `Levenshtein` at module level, but it was never declared in `install_requires`. Fresh `pip install sgraph` crashed with `ModuleNotFoundError` on `ModelCompare` and the new compare CLI. Floor `>=0.25.1` keeps Python 3.8 installable per `python_requires`.

2. **Broken converter module**: `sgraph/converters/xml_to_hierarchical_json.py` imported `sgraph_to_json_file` from a nonexistent top-level `sgraph_json` module (it lives in `sgraph.converters.sgraph_json`) and executed the conversion at import time. Now importable, with the script entry guarded by `__main__`. Regression tests added.

3. **Stale tests**: `tests/test_release_automation.py` had 6 failing tests for the PR-polling feature removed from `scripts/release.py` in d038662 (two-phase split). Removed them; added tests for `bump_version` and `_extract_pr_number` which the current script actually has.

Full suite: 161 passed. Changed files are flake8-clean.

This unblocks the 1.6.1 patch release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)