### PR TITLE
Add __version__ attribute to sgraph package

### DIFF
--- a/src/sgraph/__init__.py
+++ b/src/sgraph/__init__.py
@@ -1,6 +1,13 @@
+from importlib.metadata import version, PackageNotFoundError
+
 from sgraph.sgraph import SGraph
 from sgraph.selement import SElement
 from sgraph.exceptions import SElementMergedException, ModelNotFoundException
 from sgraph.selementassociation import SElementAssociation
 from sgraph.modelapi import ModelApi
 from sgraph.metricsapi import MetricsApi
+
+try:
+    __version__ = version("sgraph")
+except PackageNotFoundError:
+    __version__ = "unknown"

--- a/tests/sgraph_test.py
+++ b/tests/sgraph_test.py
@@ -151,3 +151,10 @@ def test_to_xml_strips_invalid_control_chars_and_roundtrips():
     # The visible content must survive intact.
     assert got.startswith('before')
     assert 'after<&"\'>' in got
+
+
+def test_version_attribute():
+    import sgraph
+
+    assert isinstance(sgraph.__version__, str)
+    assert sgraph.__version__ != ''


### PR DESCRIPTION
## Summary

Expose the standard `sgraph.__version__` attribute, resolved at import time from installed package metadata via `importlib.metadata.version()`.

- Single source of truth: the version comes from package metadata (`setup.cfg`), nothing to keep in sync manually.
- Falls back to `"unknown"` when the package is not installed (e.g. running from a plain source checkout), so importing never breaks.
- Useful for bug reports, runtime diagnostics, and downstream consumers such as [sgraph-mcp-server](https://github.com/softagram/sgraph-mcp-server) that want to report or check the library version.

Originally authored on the `supporting-__version__` branch (Feb 2026); rebased onto current `main` with a test added.

## Test plan

- New test `test_version_attribute` asserts the attribute exists and is a non-empty string (passes both installed and uninstalled thanks to the fallback).
- Full suite: 162 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)