### PR TITLE
SBOM: emit spec-valid purl types instead of '???' placeholders

### DIFF
--- a/src/sgraph/converters/sbom_cyclonedx_generator.py
+++ b/src/sgraph/converters/sbom_cyclonedx_generator.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime
 import json
 import sys
-from collections import defaultdict
+from collections import Counter, defaultdict
 
 from sgraph import SGraph, SElement
 
@@ -61,12 +61,83 @@ def parents_parent_or_parent_name_equals(elem, name):
     return elem.parent.parent and elem.parent.parent.name == name
 
 
-def bom_ref(elem, v):
-    pkgid = elem.name  # todo also use url like github.com/foo/reponame
-    if 'from' in elem.attrs:
-        pkgid = elem.name
+# purl requires the type to start with a letter and to hold only [a-z0-9.-] in its canonical
+# form (https://github.com/package-url/purl-spec), so an unresolved ecosystem cannot be spelled
+# '???'. That yields purls a purl-parsing consumer rejects, leaving the component unmatchable
+# against vulnerability data. 'generic' is the purl type for packages that fit no other type,
+# and the only registered type with no default package repository — which is exactly the case
+# for a binary committed into source control.
+FALLBACK_PURL_TYPE = 'generic'
 
-    pkgid = clean_name(pkgid)
+# Ecosystem signal for binaries committed straight into a repository: their repotype names no
+# ecosystem (the analyzer's own declaration that it could not identify one) and they have no
+# ecosystem-named ancestor, so the extension of the file referencing them is the only remaining
+# signal.
+#
+# A type is inferred only when the inferred name is by itself a complete identifier for that type.
+# nuget prohibits a namespace, so the assembly name is the whole identity and inference yields a
+# complete, matchable identifier.
+# maven requires a groupId that no file extension can supply, so inference cannot yield a complete
+# identifier at all: .jar/.war/.aar are deliberately unmapped and fall through to the fallback.
+# Same rule, opposite outcomes, because the type definitions differ. pypi and gem also prohibit a
+# namespace, so whl/egg/gem are safe to infer.
+#
+# This fixes the purl TYPE only. Package names are still emitted unencoded throughout this
+# module, so a spec-valid type does not by itself make a purl spec-conforming.
+PURL_TYPE_BY_REFERENCING_EXTENSION = {
+    'dll': 'nuget',
+    'exe': 'nuget',
+    'nupkg': 'nuget',
+    'whl': 'pypi',
+    'egg': 'pypi',
+    'gem': 'gem',
+}
+
+PURL_TYPE_SOURCE_PROPERTY = 'purlTypeResolution'
+
+
+def infer_pkgtype_from_referencing_files(elem):
+    """Infer a purl type from the extensions of the files referencing this element.
+
+    Associations onto the element's parent count as well, mirroring
+    produce_source_code_references: a reference often lands on the package directory rather than
+    on its versioned child. A reference onto a directory therefore votes for every element under
+    that directory whose type is not resolved by some stronger signal.
+
+    Ties are broken alphabetically so generated SBOMs stay byte-stable between runs, independent
+    of association traversal order. Only the extensions that voted for the winning type are
+    reported, so the provenance never cites evidence that argued for a different type.
+
+    :param elem: the external element whose purl type is being resolved
+    :return: (pkgtype, extensions) or (None, []) when no referencing file gives a hint.
+    """
+    votes = Counter()
+    extensions_by_pkgtype = defaultdict(set)
+    incoming = elem.incoming + (elem.parent.incoming if elem.parent else [])
+    for association in incoming:
+        extension = file_extension(association.fromElement).lower()
+        pkgtype = PURL_TYPE_BY_REFERENCING_EXTENSION.get(extension)
+        if pkgtype is not None:
+            votes[pkgtype] += 1
+            extensions_by_pkgtype[pkgtype].add(extension)
+    if not votes:
+        return None, []
+    winner = min(votes, key=lambda candidate: (-votes[candidate], candidate))
+    return winner, sorted(extensions_by_pkgtype[winner])
+
+
+def purl_for(elem, v):
+    """Build the purl of an element and report how its package type was resolved.
+
+    :param elem: the external element to describe
+    :param v: the version string of that element
+    :return: (purl, properties) where properties is a list of CycloneDX property dicts. It is
+             non-empty only when the type was inferred or fell back; a type resolved from an
+             attribute naming an ecosystem, or from an ecosystem-named ancestor, is not a guess
+             and gets no property.
+    """
+    properties: list[dict] = []
+    pkgid = clean_name(elem.name)  # todo also use url like github.com/foo/reponame
     if elem.attrs.get('repotype', '') == 'NPM' or parents_parent_or_parent_name_equals(elem, 'NPM'):
         pkgtype = 'npm'
     elif elem.attrs.get('repotype', '') == 'APT' or parents_parent_or_parent_name_equals(
@@ -79,8 +150,6 @@ def bom_ref(elem, v):
         pkgtype = 'golang'
     elif elem.parent.name == 'Maven':
         pkgtype = 'maven'
-    elif elem.parent.name == 'Java':
-        pkgtype = '??Java'
     elif incoming_deps(elem, ['csproj', 'vbproj'],
                        ['assembly_ref']) or parents_parent_or_parent_name_equals(
                            elem, 'Assemblies'):
@@ -91,10 +160,26 @@ def bom_ref(elem, v):
         if ' of tag ' in pkgid:
             pkgid = pkgid.split(' of tag ')[0]
     else:
-        pkgtype = '???'
+        pkgtype, extensions = infer_pkgtype_from_referencing_files(elem)
+        if pkgtype is not None:
+            properties.append({
+                'name': PURL_TYPE_SOURCE_PROPERTY,
+                'value': 'inferred from referencing file extension: ' + ','.join(extensions)
+            })
+        else:
+            pkgtype = FALLBACK_PURL_TYPE
+            properties.append({'name': PURL_TYPE_SOURCE_PROPERTY, 'value': 'ecosystem unresolved'})
 
     v = v.lstrip('^')
-    return f'pkg:{pkgtype}/{pkgid}@{v}'
+    return f'pkg:{pkgtype}/{pkgid}@{v}', properties
+
+
+def bom_ref(elem, v):
+    """Return only the purl of an element, without its type-resolution provenance.
+
+    Backward-compatible public wrapper around purl_for; do not remove.
+    """
+    return purl_for(elem, v)[0]
 
 
 # TODO License mapping not implemented
@@ -250,13 +335,14 @@ def elem_as_bom_data(elem, other_externals_by_name, external_root, noisy=False):
         v = extract_version(elem)
         if v is None:
             v = ''
-        ref = bom_ref(elem, v)
+        ref, purl_properties = purl_for(elem, v)
 
         direct_deps, indirect_deps = produce_source_code_references(elem, external_root)
         direct_deps_paths = ';'.join(sorted(direct_deps))
 
         custom_properties = []  # noqa
         custom_properties.append({'name': 'sourceCodeReferences', 'value': direct_deps_paths})
+        custom_properties.extend(purl_properties)
 
         if indirect_deps:
             custom_properties.append({'name': 'indirectExposureCount', 'value': len(indirect_deps)})
@@ -378,10 +464,13 @@ def analyze_3rdparty(external_root, sbom):
     """
 
     stack = list(external_root.children)
+    seen_refs = set()
     while stack:
         elem = stack.pop(0)
         for bom_component in elem_as_bom_data(elem, other_externals_by_name, external_root):
-            sbom.components.append(bom_component)
+            if bom_component['bom-ref'] not in seen_refs:
+                seen_refs.add(bom_component['bom-ref'])
+                sbom.components.append(bom_component)
         stack += elem.children
 
 

--- a/tests/converters/modelfile_for_sbom_binary_refs_tests.xml
+++ b/tests/converters/modelfile_for_sbom_binary_refs_tests.xml
@@ -1,0 +1,130 @@
+<model version="2.1">
+  <elements>
+    <e n="ExampleOrg">
+      <e n="repoA">
+        <e n="src">
+          <e i="10" n="Consumer.csproj" t="file">
+            <r r="60" t="assembly_ref" />
+          </e>
+          <e i="11" n="Consumer.dll" t="file">
+            <r r="30" t="ref" />
+          </e>
+          <e i="12" n="Runner.exe" t="file">
+            <r r="31" t="ref" />
+          </e>
+          <e i="13" n="Helper.DLL" t="file">
+            <r r="32" t="ref" />
+          </e>
+          <e i="14" n="Legacy.exe" t="file">
+            <r r="32" t="ref" />
+          </e>
+          <!-- builder.jar is the only reference to JvmBinary, and the only thing distinguishing an
+               unmapped extension from an element with no references at all. That distinction is the
+               premise of test_jar_referenced_binary_falls_back_to_generic. If that premise assertion
+               ever fails, restore this reference rather than relaxing the assertion. -->
+          <e i="15" n="builder.jar" t="file">
+            <r r="33" t="ref" />
+          </e>
+          <e i="16" n="sample_extension.xpi" t="file">
+            <r r="34" t="ref" />
+          </e>
+          <!-- This reference lands on the package directory, not on the versioned leaf. Do not retarget it. -->
+          <e i="17" n="Grouped.dll" t="file">
+            <r r="35" t="ref" />
+          </e>
+          <e i="18" n="packager.gem" t="file">
+            <r r="37" t="ref" />
+          </e>
+          <!-- Deliberate losing vote: nuget ties gem one to one, gem wins alphabetically. Removing this makes the tie break assertion vacuous. -->
+          <e i="19" n="Mixer.dll" t="file">
+            <r r="37" t="ref" />
+          </e>
+          <e i="20" n="Primary.dll" t="file">
+            <r r="39" t="ref" />
+          </e>
+          <e i="21" n="Secondary.dll" t="file">
+            <r r="39" t="ref" />
+          </e>
+          <!-- Deliberate losing vote: one pypi against two nuget. Removing this makes the winner only provenance assertion vacuous. -->
+          <e i="22" n="extra.whl" t="file">
+            <r r="39" t="ref" />
+          </e>
+          <e i="23" n="package.whl" t="file">
+            <r r="40" t="ref" />
+          </e>
+          <e i="24" n="legacy.egg" t="file">
+            <r r="40" t="ref" />
+          </e>
+          <e i="25" n="bundle.nupkg" t="file">
+            <r r="41" t="ref" />
+          </e>
+          <e i="26" n="Dup.dll" t="file">
+            <r r="42" t="ref" />
+          </e>
+          <e i="27" n="Dup.csproj" t="file">
+            <r r="62" t="assembly_ref" />
+          </e>
+          <e i="28" n="App.jar" t="file">
+            <r r="70" t="ref" />
+          </e>
+        </e>
+      </e>
+      <e n="External">
+        <e n="Unknown_Binary_Files">
+          <e n="Ionic.Zip">
+            <e i="30" n="Ionic.Zip of version 1.9.1.8" repotype="Unknown_Binary_Files" />
+          </e>
+          <e n="ExampleTool">
+            <e i="31" n="ExampleTool of version 2.0.1" />
+          </e>
+          <e n="MultiRefBinary">
+            <e i="32" n="MultiRefBinary of version 6.1" />
+          </e>
+          <e n="JvmBinary">
+            <e i="33" n="JvmBinary of version 4.2" />
+          </e>
+          <e n="SampleExtension">
+            <e i="34" n="SampleExtension of version 0.9" repotype="Unknown_Binary_Files" />
+          </e>
+          <e i="35" n="GroupedBinary">
+            <e i="36" n="GroupedBinary of version 3.3" />
+          </e>
+          <e n="MixedRefBinary">
+            <e i="37" n="MixedRefBinary of version 5.0" />
+          </e>
+          <e n="OrphanBinary">
+            <e i="38" n="OrphanBinary of version 7.7" />
+          </e>
+          <e n="MixedVoteBinary">
+            <e i="39" n="MixedVoteBinary of version 8.2" />
+          </e>
+          <e n="PyBinary">
+            <e i="40" n="PyBinary of version 1.2" />
+          </e>
+          <e n="NupkgBinary">
+            <e i="41" n="NupkgBinary of version 3.1" />
+          </e>
+          <e n="DupPackage">
+            <e i="42" n="DupPackage of version 2.5.0" repotype="Unknown_Binary_Files" />
+          </e>
+        </e>
+        <e n="Assemblies">
+          <e n="ExampleOrg.Common">
+            <e i="60" n="ExampleOrg.Common" version="1.4.2" />
+          </e>
+          <e n="DupPackage">
+            <e i="62" n="DupPackage" version="2.5.0" />
+          </e>
+        </e>
+        <e n="Maven">
+          <e i="61" n="org.example.sample sample-lib of version 2.4.1"
+            artifactId="sample-lib" groupId="org.example.sample"
+            repotype="Maven" version="2.4.1" />
+        </e>
+        <e n="Java">
+          <e i="70" n="somelib of version 4.1" />
+        </e>
+      </e>
+    </e>
+  </elements>
+</model>

--- a/tests/converters/sbom_cyclonedx_generator_test.py
+++ b/tests/converters/sbom_cyclonedx_generator_test.py
@@ -1,6 +1,10 @@
+import re
+
+from sgraph import SElement, SGraph
 from sgraph.converters import sbom_cyclonedx_generator
 from sgraph.converters.sbom_cyclonedx_generator import (
-    deterministic_serial, slugify_bom_ref, generate_multi_from_sgraph
+    deterministic_serial, slugify_bom_ref, generate_multi_from_sgraph,
+    infer_pkgtype_from_referencing_files
 )
 from ..modelapi_test import get_model_and_model_api
 
@@ -105,3 +109,196 @@ def test_multi_sbom_internal_dependencies():
     repo_b_sbom = next(s for s in result if s['metadata']['component']['name'] == 'repoB')
     repo_b_serial = repo_b_sbom['serialNumber'].replace('urn:uuid:', '')
     assert any(repo_b_serial in link for link in bom_link_deps)
+
+
+# --- purl type inference tests ---
+
+BINARY_REFS_MODEL = 'converters/modelfile_for_sbom_binary_refs_tests.xml'
+
+# The purl spec requires a type to start with a letter and to hold only [a-z0-9.-] in its
+# canonical form. Only the type is anchored on purpose: name encoding is a separate, pre-existing
+# concern (existing fixtures legitimately produce maven names that contain a space).
+PURL_TYPE_PATTERN = re.compile(r'^pkg:[a-z][a-z0-9.-]*/')
+
+
+def get_binary_refs_components():
+    """Generate the binary-reference SBOM and index its components by component name."""
+    model, _ = get_model_and_model_api(BINARY_REFS_MODEL)
+    sbom = sbom_cyclonedx_generator.generate_from_sgraph(model)
+    return {component['name']: component for component in sbom['components']}
+
+
+def purl_type_resolution(component):
+    """Return the purlTypeResolution property value of a component, or None when it has none."""
+    for prop in component['properties']:
+        if prop['name'] == 'purlTypeResolution':
+            return prop['value']
+    return None
+
+
+def test_dll_referenced_binary_is_typed_as_nuget():
+    """A binary referenced from a .dll gets the .NET ecosystem type instead of '???'."""
+    component = get_binary_refs_components()['Ionic.Zip']
+    assert component['purl'] == 'pkg:nuget/Ionic.Zip@1.9.1.8'
+    assert component['bom-ref'] == component['purl']
+
+
+def test_exe_referenced_binary_is_typed_as_nuget():
+    """An .exe reference is the same .NET signal as a .dll reference."""
+    assert get_binary_refs_components()['ExampleTool']['purl'] == 'pkg:nuget/ExampleTool@2.0.1'
+
+
+def test_nupkg_referenced_binary_is_typed_as_nuget():
+    """A .nupkg reference names the .NET package format directly."""
+    component = get_binary_refs_components()['NupkgBinary']
+    assert component['purl'] == 'pkg:nuget/NupkgBinary@3.1'
+    assert purl_type_resolution(component) == 'inferred from referencing file extension: nupkg'
+
+
+def test_wheel_and_egg_referenced_binary_is_typed_as_pypi():
+    """.whl and .egg both name the Python ecosystem, whose purl type prohibits a namespace."""
+    component = get_binary_refs_components()['PyBinary']
+    assert component['purl'] == 'pkg:pypi/PyBinary@1.2'
+    assert purl_type_resolution(component) == 'inferred from referencing file extension: egg,whl'
+
+
+def test_extension_matching_ignores_case_and_reports_every_winning_extension():
+    """Helper.DLL and Legacy.exe both vote nuget; the provenance lists both, sorted."""
+    component = get_binary_refs_components()['MultiRefBinary']
+    assert component['purl'] == 'pkg:nuget/MultiRefBinary@6.1'
+    assert purl_type_resolution(component) == 'inferred from referencing file extension: dll,exe'
+
+
+def test_jar_referenced_binary_falls_back_to_generic():
+    """jar/war/aar are deliberately unmapped: maven requires a groupId no extension can supply.
+
+    This asserts its own premise, unlike the other guards. No assertion on the *output* can tell
+    "referenced from a .jar" apart from "not referenced at all": both produce generic with
+    'ecosystem unresolved'. Without the premise assertion below, removing the .jar reference would
+    therefore leave this test passing while it proved only what
+    test_binary_without_any_reference_falls_back_to_generic already proves. With it, that removal
+    fails here. The extension is derived with plain string handling rather than the module's
+    file_extension helper, so the premise does not depend on the code under test.
+    """
+    model, _ = get_model_and_model_api(BINARY_REFS_MODEL)
+    elem = model.findElementFromPath(
+        '/ExampleOrg/External/Unknown_Binary_Files/JvmBinary/JvmBinary of version 4.2')
+    assert elem is not None
+    voting_extensions = {association.fromElement.name.rsplit('.', 1)[-1].lower()
+                         for association in elem.incoming + elem.parent.incoming}
+    assert voting_extensions == {'jar'}
+
+    component = get_binary_refs_components()['JvmBinary']
+    assert component['purl'] == 'pkg:generic/JvmBinary@4.2'
+    assert purl_type_resolution(component) == 'ecosystem unresolved'
+
+
+def test_unknown_extension_falls_back_to_generic():
+    """An extension with no registered purl type resolves honestly to generic."""
+    component = get_binary_refs_components()['SampleExtension']
+    assert component['purl'] == 'pkg:generic/SampleExtension@0.9'
+    assert purl_type_resolution(component) == 'ecosystem unresolved'
+
+
+def test_binary_without_any_reference_falls_back_to_generic():
+    """With no referencing file there is no signal at all, so the fallback applies."""
+    component = get_binary_refs_components()['OrphanBinary']
+    assert component['purl'] == 'pkg:generic/OrphanBinary@7.7'
+    assert purl_type_resolution(component) == 'ecosystem unresolved'
+
+
+def test_reference_on_the_package_directory_types_its_versioned_child():
+    """References often land on the package directory rather than on its versioned child."""
+    component = get_binary_refs_components()['GroupedBinary']
+    assert component['purl'] == 'pkg:nuget/GroupedBinary@3.3'
+    assert purl_type_resolution(component) == 'inferred from referencing file extension: dll'
+
+
+def test_element_under_a_java_parent_falls_back_to_generic():
+    """A parent directory named Java no longer produces the syntactically invalid '??Java'."""
+    component = get_binary_refs_components()['somelib']
+    assert component['purl'] == 'pkg:generic/somelib@4.1'
+    assert purl_type_resolution(component) == 'ecosystem unresolved'
+
+
+def test_tie_between_candidate_types_is_broken_alphabetically():
+    """One .gem and one .dll reference tie; gem wins by name so output cannot depend on order."""
+    component = get_binary_refs_components()['MixedRefBinary']
+    assert component['purl'] == 'pkg:gem/MixedRefBinary@5.0'
+    assert purl_type_resolution(component) == 'inferred from referencing file extension: gem'
+
+
+# --- purl provenance property tests ---
+
+
+def test_provenance_cites_only_the_extensions_that_voted_for_the_winning_type():
+    """Two .dll and one .whl: nuget wins 2-1, so the losing .whl is not cited as evidence.
+
+    The .whl referencing MixedVoteBinary in the fixture is the deliberate losing vote and must
+    not be removed: without it this guard cannot fail.
+    """
+    component = get_binary_refs_components()['MixedVoteBinary']
+    assert component['purl'] == 'pkg:nuget/MixedVoteBinary@8.2'
+    assert purl_type_resolution(component) == 'inferred from referencing file extension: dll'
+
+
+def test_repotype_that_names_no_ecosystem_still_gets_provenance():
+    """A repotype of 'Unknown_Binary_Files' resolves nothing, so the type is still a guess."""
+    model, _ = get_model_and_model_api(BINARY_REFS_MODEL)
+    elem = model.findElementFromPath(
+        '/ExampleOrg/External/Unknown_Binary_Files/Ionic.Zip/Ionic.Zip of version 1.9.1.8')
+    assert elem is not None
+    assert elem.attrs['repotype'] == 'Unknown_Binary_Files'
+    component = get_binary_refs_components()['Ionic.Zip']
+    assert purl_type_resolution(component) == 'inferred from referencing file extension: dll'
+
+
+def test_types_read_from_attributes_or_ancestors_carry_no_provenance():
+    """A type resolved from an attribute naming an ecosystem is not a guess and is not labelled."""
+    components = get_binary_refs_components()
+    assert components['ExampleOrg.Common']['purl'] == 'pkg:nuget/ExampleOrg.Common@1.4.2'
+    assert purl_type_resolution(components['ExampleOrg.Common']) is None
+    maven_component = components['org.example.sample sample-lib']
+    # Characterization of known-nonconforming output: the name keeps its literal space (names
+    # are emitted unencoded — see the type-only caveat in the generator). A name-encoding fix
+    # should update this expected string, not relax the assertion.
+    assert maven_component['purl'] == 'pkg:maven/org.example.sample sample-lib@2.4.1'
+    assert purl_type_resolution(maven_component) is None
+
+
+# --- purl spec conformance guard tests ---
+
+
+def test_every_generated_purl_has_a_spec_valid_type():
+    """Regression guard: encode the purl-spec type invariant, not a list of expected values."""
+    for model_file in (BINARY_REFS_MODEL, 'converters/modelfile_for_sbom_tests.xml'):
+        model, _ = get_model_and_model_api(model_file)
+        sbom = sbom_cyclonedx_generator.generate_from_sgraph(model)
+        assert sbom['components']
+        for component in sbom['components']:
+            assert PURL_TYPE_PATTERN.match(component['purl']), component['purl']
+            assert PURL_TYPE_PATTERN.match(component['bom-ref']), component['bom-ref']
+
+
+def test_single_sbom_never_repeats_a_bom_ref():
+    """CycloneDX requires bom-ref to be unique; the same package can be reached by two routes."""
+    model, _ = get_model_and_model_api(BINARY_REFS_MODEL)
+    sbom = sbom_cyclonedx_generator.generate_from_sgraph(model)
+    bom_refs = [component['bom-ref'] for component in sbom['components']]
+    assert bom_refs.count('pkg:nuget/DupPackage@2.5.0') == 1
+    assert len(bom_refs) == len(set(bom_refs))
+
+
+def test_infer_pkgtype_handles_element_without_a_parent():
+    """The inference function is callable on a root element, which has no parent to consult."""
+    model = SGraph(SElement(None, ''))
+    assert infer_pkgtype_from_referencing_files(model.rootNode) == (None, [])
+
+
+def test_bom_ref_still_returns_only_the_purl_string():
+    """The public bom_ref signature and return type are unchanged by the provenance split."""
+    model, _ = get_model_and_model_api(BINARY_REFS_MODEL)
+    elem = model.findElementFromPath(
+        '/ExampleOrg/External/Unknown_Binary_Files/Ionic.Zip/Ionic.Zip of version 1.9.1.8')
+    assert elem is not None
+    assert sbom_cyclonedx_generator.bom_ref(elem, '1.9.1.8') == 'pkg:nuget/Ionic.Zip@1.9.1.8'


### PR DESCRIPTION
## Problem

`bom_ref()` in the CycloneDX generator falls back to `pkg:???/<name>@<version>` when it
cannot resolve an ecosystem, and to `pkg:??Java/...` for elements under a parent named
`Java`.

Neither is a valid package URL. The [purl spec](https://github.com/package-url/purl-spec)
requires the type to begin with a letter and hold only letters, digits, `.` and `-`, and to
be canonically lowercase; the spec's own test vectors
reject a `?` in the type. Validating consumers (Dependency-Track, for example) reject such
components outright, so they are never matched against vulnerability databases — the
affected components are invisible in exactly the tooling an SBOM exists to feed.

In a large real-world model (674 SBOMs, ~12.5k components) this affected 115 components,
several of them packages with known critical CVEs.

## Cause

The affected elements all share one shape: a binary committed into the repository and
referenced from source, with

- either no `repotype` attribute, or one that names no ecosystem — the analyzer's own
  record that it could not identify one,
- no ecosystem-named ancestor (`NPM`, `PIP`, `Maven`, `Assemblies`),
- incoming `ref` associations from `t="file"` elements — typically `.dll`, sometimes `.exe`.

These are legacy .NET `<Reference><HintPath>` pointers at checked-in assemblies, not
package-manager dependencies. Both existing inference paths (attribute, ancestor name) have
nothing to read. The one remaining signal is the extension of the referencing file.

## Change

This is two things, and it is worth separating them because only one is spec-backed:

- **A conformance fix.** `???` and `??Java` are invalid types; `generic` is the correct
  fallback. No judgement is involved and the spec settles it.
- **A labelled ecosystem inference.** Guessing `nuget` from a referencing `.dll` is an
  inference the spec neither blesses nor forbids — `nuget` identifies packages *from
  nuget.org*, not .NET assemblies in general, and purl has no type for a bare assembly. It
  is justified empirically, by assembly names routinely equalling NuGet package ids.

The `purlTypeResolution` property below is what keeps the two distinguishable in the
output, so a consumer can filter the second out and keep the first.

1. `infer_pkgtype_from_referencing_files(elem)` derives a purl type from the extensions of
   the files referencing the element, via a documented mapping (`dll`/`exe`/`nupkg` →
   `nuget`, `whl`/`egg` → `pypi`, `gem` → `gem`). A type is inferred only where the
   inferred name is by itself a complete package identifier for that type — see
   "Why `dll`/`exe` map to `nuget` but `.jar` does not" below. Extensions are counted
   rather than taken first-hit, since a binary can be referenced from several file kinds;
   ties break alphabetically so output stays byte-stable across runs.
2. The unresolved fallback becomes `generic` — the purl type for packages that fit no
   other type, and the only registered type with no repository behind it — instead of
   `???`. The spec asks that another type be used where possible; inference runs first and
   `generic` is reached only when it finds nothing, which satisfies that constraint. (A
   `sid` type for binary-only software with no registry behind it is proposed but not
   adopted, so `generic` is correct today and there is a named successor to watch.)
3. The `??Java` branch is removed. Elements under a `Java` parent go through the same
   inference, which for JVM artifacts resolves to `generic` (see limitation 2).
4. `analyze_3rdparty()` now skips a component whose `bom-ref` it has already emitted,
   mirroring the `seen_refs` guard that `_collect_3rdparty_for_subtree()` has always had.
   Without it, making previously-distinct purls agree would make them collide as
   `bom-ref`s — and CycloneDX requires those to be unique within a BOM. JSON Schema cannot
   express that constraint, but the XML schema can and does, at document scope: a duplicate
   rejects the whole document rather than one component. Fixing purl types while opening
   that hole would trade a component-scoped defect for a document-scoped one.
5. `bom_ref()` becomes a thin wrapper over a new `purl_for()` that additionally returns
   provenance properties. The signature, return type and behaviour of `bom_ref()` are
   unchanged.

## Provenance: guesses are labelled

Any component whose type was inferred or fell back carries a `purlTypeResolution` property:

```json
"purl": "pkg:nuget/Example.Web.UI@2019.1.115.45",
"properties": [
  { "name": "purlTypeResolution",
    "value": "inferred from referencing file extension: dll" }
]
```

A type read from `repotype` or from an ecosystem-named ancestor gets no such property. Read
that absence precisely: it means the type was not inferred *by this mechanism*, not that it
is certainly right. The pre-existing ancestor-name branches are themselves heuristics — they
are simply older and unlabelled, and relabelling them would change output for every existing
component, so it is left alone here. The value cites only the extensions
that voted for the winning type, so it never lists evidence that argued against the type
actually chosen.

`component.properties` is CycloneDX's sanctioned place for this and is what the module
already uses for `sourceCodeReferences`. `component.evidence.identity` (technique
`filename`) would be the standards-idiomatic home for identity provenance specifically, and
is the natural follow-up; it is not adopted here because it would make this one field
inconsistent with the module's existing property-based convention for no gain in validity.

**Migration note:** anyone currently grepping for `pkg:???` as an "unresolved ecosystem"
marker should switch to the `purlTypeResolution` property with the value
`ecosystem unresolved`, which is now the discriminator. This matters more than a rename:
`???` announced its own failure, whereas `pkg:generic/...` looks plausible while matching
nothing. The property is what keeps unresolved components findable (see limitation 7).

## Why `dll`/`exe` map to `nuget` but `.jar` does not

The rule governing the map: infer a type only when the inferred name is by itself a
complete identifier for that type. Whether that holds depends on the purl type definition,
and the two ecosystems differ.

`nuget` prohibits a namespace — the package id is the whole identity. A HintPath assembly
reference is not proof of a NuGet package, but assembly names routinely match real package
ids, so the inferred purl carries a complete identifier and stands a real chance of
matching. An in-house
assembly gets a purl that matches nothing in any database — a harmless miss rather than a
false alarm.

`maven` requires a groupId namespace, and Maven Central identity is `groupId:artifactId`.
A file extension supplies no groupId and no way to derive one, so `pkg:maven/<artifact>@<v>`
would be malformed *and* unmatchable — an artifact name alone is ambiguous across groups.
Mapping `jar`/`war`/`aar` to `maven` would therefore trade one class of invalid purl for
another, which is exactly what this change exists to stop. JVM artifacts fall through to
`generic` instead.

The `purlTypeResolution` property keeps every inference auditable either way. Note that it
cannot rescue a malformed purl: a validating consumer rejects the component before any
property is read, which is why the completeness rule gates the map rather than provenance
alone.

## Effect on a real model (reported, not reproduced here)

These figures come from the environment where the problem was found: same model, same
command, this change the only variable, measured on the per-element path
(`generate_multi_from_sgraph`). That environment is not reachable from this repository, so
they are reported rather than independently reproduced. "What was verified here" below
separates the two.

| | before | after |
|---|---|---|
| `???` types | 115 | 0 |
| purls with a spec-invalid type | 115 | 0 |
| `nuget` | 6457 | 6539 |
| `generic` | 0 | 2 |
| npm / docker / pypi | unchanged | unchanged |
| components total | 12490 | 12459 |

The component total drops by 31 because those formerly-`???` components now resolve to
purls that already existed as NuGet components in the same SBOM. The same package had been
counted twice — once as an `assembly_ref` from a csproj/vbproj, once as the committed DLL —
and now collapses to one entry. This is a correction, not lost data.

Reduced to the smallest case that shows it, with `bom_ref` as the only variable:

```
before : 4 components   pkg:nuget/Ionic.Zip@1.9.1.8
                        pkg:???/Ionic.Zip@1.9.1.8      <- same package, counted twice
after  : 3 components   pkg:nuget/Ionic.Zip@1.9.1.8    <- one entry
```

Both output paths now collapse such a pair, because change 4 gives the single-SBOM path
the same `bom-ref` guard the per-element path already had. Before that guard the two
components would have survived side by side there, sharing one `bom-ref`.

## What was verified here

Measured over eight models available to this change, single-SBOM path, before and after:

```
                            before   after
components                    1761     1729
unique bom-refs               1729     1729
purls with an invalid type       6        0
duplicate bom-refs              32        0
```

The six become `generic`, each carrying a `purlTypeResolution` property.

The conformance half is therefore reproduced rather than reported: real models emit invalid
purl types today and stop after the change. The last row is the `bom-ref` guard on its own,
and it is the clearer statement of what that guard does — those 32 duplicates existed
beforehand and CycloneDX does not permit them, so the guard repairs a live document-level
defect rather than only preventing one this change would otherwise have introduced. The
32-component drop is the same guard, concentrated entirely in one of the eight models
(limitation 5).

Note what those six became — `generic`, every one of them, and no mapped ecosystem type.
The inference half never fired here, because no model available to this change contains a
single `.dll`, `.exe`, `.nupkg`, `.whl`, `.egg` or `.gem`; there is one `.jar` in total.

Also reproduced, against the new fixtures: the `generic` fallback, the presence and absence
of the provenance property, the alphabetical tie-break, the removal of the `??Java` branch,
and the deduplication pair shown above.

The map's entries do not all rest on the same kind of evidence, and it is worth being
explicit about which:

| entry | evidence |
|---|---|
| `nupkg` → `nuget` | true by definition — a `.nupkg` *is* a NuGet package |
| `dll`/`exe` → `nuget` | structural validity from the nuget type definition; field support reported from the environment above, not reproduced here |
| `whl`/`egg` → `pypi`, `gem` → `gem` | structural validity only; no field evidence of any kind, in either environment |

The reported extension distribution and component counts therefore rest on the reference
environment alone.

The separation that matters for review: the change's **justification** is the conformance
argument — measured above, six invalid types to zero — plus the structural validity of each
mapped type, which is checkable from the purl type definitions. Neither needs the reported
figures. Those are the change's **motivation**: they say the problem was worth fixing and at
what scale, not whether the fix is correct. Nothing in the design depends on them, which is
why they are attributed rather than asserted.

## Known limitations

1. In-house assemblies are not distinguished from third-party ones. An in-house DLL that
   happens to share a name with a real NuGet package produces a false-positive purl. A
   precise fix needs model-root access inside `purl_for()`; out of scope here.
2. JVM binaries (`.jar`/`.war`/`.aar`) resolve to `generic` and so get no vulnerability
   matching, for the reason given above: a maven purl needs a groupId that no file
   extension can supply. Recovering coordinates from a JAR's `META-INF/maven/*/pom.properties`,
   or from a pom.xml elsewhere in the model, would make the inference possible later. Out
   of scope here, and deliberately left as an honest gap rather than a plausible-looking
   guess that would match nothing anyway.
3. Inference reads the element's own incoming references *and its parent's*, matching what
   `produce_source_code_references()` already does. Where several versioned children share
   one name directory, a reference landing on that directory votes for every unresolved
   child, so the recorded evidence can be broader than the evidence for one specific child.
4. Where an inferred component collapses into a pre-existing equivalent on the per-element
   path, the surviving `sourceCodeReferences` point at the DLL rather than at the csproj.
   Because `seen_refs` keeps whichever component it met first, the survivor can also lose a
   `purlTypeResolution` label its twin carried, or keep one when the discarded twin was
   authoritatively typed. That is at stake only where a collision pairs an inferred
   component with an ancestor-resolved one: there exactly one twin carries the label, so
   traversal order decides which survives. A collision can equally pair two
   ancestor-resolved components, with no label on either side and nothing to lose — which
   describes every one of the 32 collisions measured across the models available here. So
   where this bites is the mixed class, and no mixed collision occurs in any model
   available to this change. It is inferred rather than measured that the reference
   environment's merges were of that kind: they are reported there as formerly-`???`
   components meeting the `assembly_ref` twins they had been double-counted against, and
   that pairing is one inferred component and one ancestor-resolved one. This is existing
   `_collect_3rdparty_for_subtree` behaviour, not introduced here, but this change makes
   more components collide and so makes it more visible.
5. The `bom-ref` guard on the single-SBOM path also collapses duplicates that predate this
   change — any two externals resolving to the same purl already collided there. Measured
   across eight models, seven were unaffected and one lost 32 of 261 components, so the
   effect is real but concentrated. That model's single-SBOM output already carried 32
   duplicate `bom-ref`s and was invalid under the XML schema before any change here, so
   the guard repairs it rather than degrading it. No distinct package is lost: collapse is
   by identical purl, every unique purl survives, and vulnerability matching keys on purl.
   What narrows is `sourceCodeReferences` — the guard discards rather than merges, and the
   survivor is whichever the traversal reaches first, so it may be the twin with the
   shorter reference list. Merging the two lists instead would preserve them, but that is
   a different semantic than the per-element path has ever applied and belongs in its own
   change. One class this closes was already invalid under JSON Schema too: two
   indistinguishable unresolved elements produced byte-identical component objects, which
   `bom.components` forbids via `uniqueItems`.
6. Only the purl *type* is fixed, so the regression test guards the type only. Two
   independent conformance gaps remain and are deliberately not touched: package *names*
   are emitted unencoded, so pre-existing components whose names contain literal spaces
   stay non-conformant; and the existing `Maven` ancestor branch emits `pkg:maven/<name>`
   without the groupId namespace that the maven type requires — the same namespace problem
   that keeps `jar` out of the inference map, in a branch this change does not touch.
   Widening the fix to those would change output well beyond the paths measured above.
7. Ecosystem buckets are matched at inconsistent nesting depths. `NPM`, `APT`, `PIP` and
   `Assemblies` match a parent *or* grandparent; `Python`, `Go` and `Maven` match only a
   direct parent, although the documented `External/` layout nests packages one level
   deeper. Packages nested under `Python`, `Go` or `Maven` therefore miss their branch and
   fall to inference, which has no mapping for `.py` or `.go` and so yields `generic`.
   Before this change they yielded `???`. Both are wrong, but `???` was loud and greppable
   where `generic` looks plausible, so this change makes an existing failure quieter — the
   `purlTypeResolution` property is what keeps it detectable. Aligning those three branches
   is a small, obvious follow-up; it is excluded here because it changes branches the
   measurements above did not exercise.
8. Licenses remain empty for these components — a separate concern.

## Tests

New fixture `tests/converters/modelfile_for_sbom_binary_refs_tests.xml` reproduces the
production shape: both attribute variants — absent, and a `repotype` naming no ecosystem —
with the version in the `' of version '` name suffix and a `ref` association from a
`t="file"` element. New tests cover each mapped extension family, the
`generic` fallback, presence and absence of the provenance property, the alphabetical
tie-break that keeps output byte-stable, and the removal of the `??Java` branch.
A `.jar`-referenced binary is asserted to yield `generic` rather than `maven`, so
the deliberate exclusion is pinned by a test and cannot be "fixed" back into a defect. One
regression test asserts the spec invariant itself over every generated purl:

```python
PURL_TYPE_PATTERN = re.compile(r'^pkg:[a-z][a-z0-9.-]*/')
```

encoding the rule rather than a list of expected strings, so future ecosystem additions
cannot silently reintroduce an invalid type.

The guard is deliberately type-scoped, and the fixture carries a witness for why: one
component emits a maven purl whose *name* contains a literal space. That component is
asserted as-is rather than corrected, so the name-encoding gap in limitation 6 is recorded
as executable characterization rather than left as prose — and so a future full-purl
validator has a known case to fail against.

Existing tests are unchanged and pass.
